### PR TITLE
Add iBus related package.

### DIFF
--- a/port-files/Makefile
+++ b/port-files/Makefile
@@ -50,6 +50,10 @@ RUN_DEPENDS=	${LOCALBASE}/sbin/PCDMd:x11/pcdm \
 		xv>=0:graphics/xv \
 		powerdxx>=0:sysutils/powerdxx \
 		tor>=0:security/tor \
+		ibus-m17n>=0:textproc/ibus-m17n \
+		zh-ibus-chewing>=0:chinese/ibus-chewing \
+		ja-ibus-mozc>=0:japanese/ibus-mozc \
+		ko-ibus-hangul>=0:korean/ibus-hangul \
 		socat>=0:net/socat
 
 WRKSRC_SUBDIR=  xtrafiles


### PR DESCRIPTION
TrueOS desktop removed iBus related package.  Chinese/Japanese/Korean/others language users cannot type in their language.
