### PR TITLE
Add chinese/fcitx-configtool(fcitx GUI configuration tool)

### DIFF
--- a/port-files/Makefile
+++ b/port-files/Makefile
@@ -54,6 +54,7 @@ RUN_DEPENDS=	${LOCALBASE}/sbin/PCDMd:x11/pcdm \
 		fcitx-qt5>=0:textproc/fcitx-qt5 \
 		ja-fcitx-mozc>=0:japanese/fcitx-mozc \
 		ko-fcitx-hangul>=0:korean/fcitx-hangul \
+		zh-fcitx-configtool>=0:chinese/fcitx-configtool \
 		zh-fcitx-chewing>=0:chinese/fcitx-chewing \
 		zh-fcitx-googlepinyin>=0:chinese/fcitx-googlepinyin \
 		socat>=0:net/socat


### PR DESCRIPTION
Current fcitx personal configuration is edit ~/.config/fcitx/\* with
text-editor.  fcitx-configtool enable GUI configuration.
